### PR TITLE
Peer dep

### DIFF
--- a/.changeset/curvy-fans-hammer.md
+++ b/.changeset/curvy-fans-hammer.md
@@ -1,0 +1,7 @@
+---
+'lariat': minor
+---
+
+Update to use `@playwright/test` as a peer dependency. This should resolve the
+problem when updating Playwright versions of also having to update
+`playwright-core`.

--- a/package.json
+++ b/package.json
@@ -28,14 +28,14 @@
     "test": "playwright test",
     "release": "./scripts/release.sh"
   },
-  "dependencies": {
-    "playwright-core": "^1.27.1"
+  "peerDependencies": {
+    "@playwright/test": ">=1.28.0"
   },
   "devDependencies": {
     "@babel/core": "^7.18.2",
     "@babel/eslint-parser": "^7.19.1",
     "@changesets/cli": "^2.22.0",
-    "@playwright/test": "^1.27.1",
+    "@playwright/test": "^1.30.0",
     "@typescript-eslint/eslint-plugin": "^5.42.0",
     "@typescript-eslint/parser": "^5.42.0",
     "eslint": "^8.26.0",

--- a/src/Collection.ts
+++ b/src/Collection.ts
@@ -1,8 +1,8 @@
-import type { Frame, FrameLocator, Locator, Page } from 'playwright-core'
+import type { Frame, FrameLocator, Locator, Page } from '@playwright/test'
 import { enhance, NestedCollection } from './enhance'
 import { Handle, isLocator } from './utils'
 
-interface SelectorOptions {
+export interface SelectorOptions {
   /**
    * When defined, creates a frame locator which the element will be nested
    * inside of.

--- a/src/enhance.ts
+++ b/src/enhance.ts
@@ -1,4 +1,4 @@
-import type { FrameLocator, Locator } from 'playwright-core'
+import type { FrameLocator, Locator } from '@playwright/test'
 
 export type NestedCollection<T> = T & {
   first(): T

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,4 @@
 import { Collection } from './Collection'
+export type { SelectorOptions } from './Collection'
+export type { Handle } from './utils'
 export default Collection

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import type { Frame, FrameLocator, Locator, Page } from 'playwright-core'
+import type { Frame, FrameLocator, Locator, Page } from '@playwright/test'
 
 export type Handle = Page | Frame | FrameLocator | Locator
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -700,15 +700,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@playwright/test@npm:^1.27.1":
-  version: 1.27.1
-  resolution: "@playwright/test@npm:1.27.1"
+"@playwright/test@npm:^1.30.0":
+  version: 1.30.0
+  resolution: "@playwright/test@npm:1.30.0"
   dependencies:
     "@types/node": "*"
-    playwright-core: 1.27.1
+    playwright-core: 1.30.0
   bin:
     playwright: cli.js
-  checksum: 92f219a78c21da03c6599d92c313c914e73cc374306366130fb3bd4701555179394ec5a3000d9375ce59f5a03c00f20d1ddaae50c85583ce475e17795a622699
+  checksum: 777432ac9cf3d0341fcd8dd265cb4c0775619d0ef48252b32a7c4d632d8038449756ec34bec873828cadbc08ba634e81176cb193304d34e699472771b7fb4d1e
   languageName: node
   linkType: hard
 
@@ -2236,7 +2236,7 @@ __metadata:
     "@babel/core": ^7.18.2
     "@babel/eslint-parser": ^7.19.1
     "@changesets/cli": ^2.22.0
-    "@playwright/test": ^1.27.1
+    "@playwright/test": ^1.30.0
     "@typescript-eslint/eslint-plugin": ^5.42.0
     "@typescript-eslint/parser": ^5.42.0
     eslint: ^8.26.0
@@ -2244,9 +2244,10 @@ __metadata:
     eslint-plugin-playwright: ^0.11.2
     eslint-plugin-sort: ^2.4.0
     eslint-plugin-widen: ^1.0.0
-    playwright-core: ^1.27.1
     prettier: ^2.6.2
     typescript: ^4.7.2
+  peerDependencies:
+    "@playwright/test": ">=1.28.0"
   languageName: unknown
   linkType: soft
 
@@ -2645,12 +2646,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.27.1, playwright-core@npm:^1.27.1":
-  version: 1.27.1
-  resolution: "playwright-core@npm:1.27.1"
+"playwright-core@npm:1.30.0":
+  version: 1.30.0
+  resolution: "playwright-core@npm:1.30.0"
   bin:
     playwright: cli.js
-  checksum: fd65d3eb29978e0e7a755158625e8922a66ca9d599b7c24ddf920822b261d81c51a5964ef8e0e5ed9b2b12dc64541c5949b6a898d965e107f43261964e8c29a0
+  checksum: 4c5693f27245a1168f94708ecd8e1eb0d200de435b25cc07cfa25b97a094633818954dc00baf24e0ff551825f672050b83d1309362c1f97213fe8ebd2a147ed9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Update to use `@playwright/test` as a peer dependency. This should resolve the problem when updating Playwright versions of also having to update `playwright-core`.